### PR TITLE
Pretty print AI model metadata

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -45,7 +45,7 @@
     {
      "data": {
       "text/plain": [
-       "ExtrinsicProperties(Hc=Entity(ontology_label='CoercivityHcExternal', value=np.float32(7.232628e+06), unit='A / m'), Mr=Entity(ontology_label='Remanence', value=np.float32(1.0256044e+06), unit='A / m'), BHmax=Entity(ontology_label='MaximumEnergyProduct', value=np.float32(330440.28), unit='J / m3'))"
+       "ExtrinsicProperties(Hc=Entity(ontology_label='CoercivityHcExternal', value=np.float32(7.232621e+06), unit='A / m'), Mr=Entity(ontology_label='Remanence', value=np.float32(1.0256044e+06), unit='A / m'), BHmax=Entity(ontology_label='MaximumEnergyProduct', value=np.float32(330440.28), unit='J / m3'))"
       ]
      },
      "execution_count": 2,
@@ -79,10 +79,10 @@
     {
      "data": {
       "text/html": [
-       "<samp>CoercivityHcExternal(value=7232628.0,&nbsp;unit=A&nbsp;/&nbsp;m)</samp>"
+       "<samp>CoercivityHcExternal(value=7232621.0,&nbsp;unit=A&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='CoercivityHcExternal', value=np.float32(7.232628e+06), unit='A / m')"
+       "Entity(ontology_label='CoercivityHcExternal', value=np.float32(7.232621e+06), unit='A / m')"
       ]
      },
      "execution_count": 3,
@@ -225,24 +225,20 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'model_name': 'cube50_singlegrain_random_forest_v0.1',\n",
-       " 'description': 'Random forest model trained on simulated data for single grain cubic particles with 50 nm edge length with the external field applied parallel to the anisotropy axis.',\n",
-       " 'training_data_range': {'Ms': (Entity(ontology_label='SpontaneousMagnetization', value=np.float64(79580.0), unit='A / m'),\n",
-       "   Entity(ontology_label='SpontaneousMagnetization', value=np.float64(3980000.0), unit='A / m')),\n",
-       "  'A': (Entity(ontology_label='ExchangeStiffnessConstant', value=np.float64(1e-13), unit='J / m'),\n",
-       "   Entity(ontology_label='ExchangeStiffnessConstant', value=np.float64(1e-11), unit='J / m')),\n",
-       "  'K': (Entity(ontology_label='UniaxialAnisotropyConstant', value=np.float64(10000.0), unit='J / m3'),\n",
-       "   Entity(ontology_label='UniaxialAnisotropyConstant', value=np.float64(10000000.0), unit='J / m3'))},\n",
-       " 'input_parameters': ['Ms (A/m)', 'A (J/m)', 'K1 (J/m^3)'],\n",
-       " 'output_parameters': ['Hc (A/m)', 'Mr (A/m)', 'BHmax (J/m^3)'],\n",
-       " 'source': 'https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model'}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'description': 'Random forest model trained on simulated data for single '\n",
+      "                'grain cubic particles with 50 nm edge length with the '\n",
+      "                'external field applied parallel to the anisotropy axis.',\n",
+      " 'input_parameters': ['Ms (A/m)', 'A (J/m)', 'K1 (J/m^3)'],\n",
+      " 'model_name': 'cube50_singlegrain_random_forest_v0.1',\n",
+      " 'output_parameters': ['Hc (A/m)', 'Mr (A/m)', 'BHmax (J/m^3)'],\n",
+      " 'source': 'https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model',\n",
+      " 'training_data_range': {'A': [1e-13 J / m, 1e-11 J / m],\n",
+      "                         'K': [10000.0 J / m3, 10000000.0 J / m3],\n",
+      "                         'Ms': [79580.0 A / m, 3980000.0 A / m]}}\n"
+     ]
     }
    ],
    "source": [
@@ -256,24 +252,20 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "{'model_name': 'cube50_singlegrain_random_forest_v0.1',\n",
-       " 'description': 'Random forest model trained on simulated data for single grain cubic particles with 50 nm edge length with the external field applied parallel to the anisotropy axis.',\n",
-       " 'training_data_range': {'Ms': (Entity(ontology_label='SpontaneousMagnetization', value=np.float64(79580.0), unit='A / m'),\n",
-       "   Entity(ontology_label='SpontaneousMagnetization', value=np.float64(3980000.0), unit='A / m')),\n",
-       "  'A': (Entity(ontology_label='ExchangeStiffnessConstant', value=np.float64(1e-13), unit='J / m'),\n",
-       "   Entity(ontology_label='ExchangeStiffnessConstant', value=np.float64(1e-11), unit='J / m')),\n",
-       "  'K': (Entity(ontology_label='UniaxialAnisotropyConstant', value=np.float64(10000.0), unit='J / m3'),\n",
-       "   Entity(ontology_label='UniaxialAnisotropyConstant', value=np.float64(10000000.0), unit='J / m3'))},\n",
-       " 'input_parameters': ['Ms (A/m)', 'A (J/m)', 'K1 (J/m^3)'],\n",
-       " 'output_classes': {0: 'soft magnetic', 1: 'hard magnetic'},\n",
-       " 'source': 'https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model'}"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'description': 'Random forest model trained on simulated data for single '\n",
+      "                'grain cubic particles with 50 nm edge length with the '\n",
+      "                'external field applied parallel to the anisotropy axis.',\n",
+      " 'input_parameters': ['Ms (A/m)', 'A (J/m)', 'K1 (J/m^3)'],\n",
+      " 'model_name': 'cube50_singlegrain_random_forest_v0.1',\n",
+      " 'output_classes': {0: 'soft magnetic', 1: 'hard magnetic'},\n",
+      " 'source': 'https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model',\n",
+      " 'training_data_range': {'A': [1e-13 J / m, 1e-11 J / m],\n",
+      "                         'K': [10000.0 J / m3, 10000000.0 J / m3],\n",
+      "                         'Ms': [79580.0 A / m, 3980000.0 A / m]}}\n"
+     ]
     }
    ],
    "source": [
@@ -283,7 +275,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "default",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/src/mammos_ai/_beyond_stoner_wohlfarth_fixed_angle/__init__.py
+++ b/src/mammos_ai/_beyond_stoner_wohlfarth_fixed_angle/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from pprint import pprint
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -113,8 +114,8 @@ def is_hard_magnet_from_Ms_A_K(
 
 def is_hard_magnet_from_Ms_A_K_metadata(
     model: str = "cube50_singlegrain_random_forest_v0.1",
-) -> dict:
-    """Get metadata for the specified classification model.
+):
+    """Print metadata for the specified classification model.
 
     Args:
        model: AI model used for the classification
@@ -130,18 +131,24 @@ def is_hard_magnet_from_Ms_A_K_metadata(
                     "applied parallel to the anisotropy axis."
                 ),
                 "training_data_range": {
-                    "Ms": (me.Ms(79.58e3), me.Ms(3.98e6)),
-                    "A": (me.A(1e-13), me.A(1e-11)),
-                    "K": (me.Ku(1e4), me.Ku(1e7)),
+                    "Ms": [me.Ms(79.58e3), me.Ms(3.98e6)],
+                    "A": [me.A(1e-13), me.A(1e-11)],
+                    "K": [me.Ku(1e4), me.Ku(1e7)],
                 },
                 "input_parameters": ["Ms (A/m)", "A (J/m)", "K1 (J/m^3)"],
                 "output_classes": {0: "soft magnetic", 1: "hard magnetic"},
                 "source": "https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model",
             }
+            original_repr = me.Entity.__repr__
+
+            def override_entity_repr(obj):
+                return str(obj.q)
+
+            me.Entity.__repr__ = override_entity_repr
+            pprint(metadata)
+            me.Entity.__repr__ = original_repr
         case _:
             raise ValueError(f"Unknown model {model}")
-
-    return metadata
 
 
 def _predict_cube50_singlegrain_random_forest_v0_1(
@@ -267,8 +274,8 @@ def Hc_Mr_BHmax_from_Ms_A_K(
 
 def Hc_Mr_BHmax_from_Ms_A_K_metadata(
     model: str = "cube50_singlegrain_random_forest_v0.1",
-) -> dict:
-    """Get metadata for the specified Hc, Mr, BHmax prediction model.
+):
+    """Print metadata for the specified Hc, Mr, BHmax prediction model.
 
     Args:
        model: AI model used for the prediction
@@ -284,14 +291,21 @@ def Hc_Mr_BHmax_from_Ms_A_K_metadata(
                     "applied parallel to the anisotropy axis."
                 ),
                 "training_data_range": {
-                    "Ms": (me.Ms(79.58e3), me.Ms(3.98e6)),
-                    "A": (me.A(1e-13), me.A(1e-11)),
-                    "K": (me.Ku(1e4), me.Ku(1e7)),
+                    "Ms": [me.Ms(79.58e3), me.Ms(3.98e6)],
+                    "A": [me.A(1e-13), me.A(1e-11)],
+                    "K": [me.Ku(1e4), me.Ku(1e7)],
                 },
                 "input_parameters": ["Ms (A/m)", "A (J/m)", "K1 (J/m^3)"],
                 "output_parameters": ["Hc (A/m)", "Mr (A/m)", "BHmax (J/m^3)"],
                 "source": "https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model",
             }
+            original_repr = me.Entity.__repr__
+
+            def override_entity_repr(obj):
+                return str(obj.q)
+
+            me.Entity.__repr__ = override_entity_repr
+            pprint(metadata)
+            me.Entity.__repr__ = original_repr
         case _:
             raise ValueError(f"Unknown model {model}")
-    return metadata


### PR DESCRIPTION
Extremely ugly fix to print AI model metadata in a pretty way:
![](https://media1.tenor.com/m/1OYYI7xS5YUAAAAd/awkward-stare.gif)

The down side is that the functions `Hc_Mr_BHmax_from_Ms_A_K_metadata` and `is_hard_magnet_from_Ms_A_K_metadata` do not return a dictionary, they just print it. The upside is it looks good in the notebook.

**<ins>Short term solution</ins>:** @andrea-petrocchi suggested creation of a `MetaData` class which lets us print the contents the way we want.
**<ins>Long term solution</ins>:** I think the best long term solution would be to create an `AIModel` data class that houses the metadata corresponding to its training process and inputs. Further we can provide an `available_AI_models` enum that points to right `AIModel` objects. The best part of exposing the available models as an enum is that one can tab_complete the selected model. So the API would look something like:
```python
>>> import mammos_ai as mai
>>> mai.available_AI_models.classifier_cube50_singlegrain_random_forest_v0_1 # tab-completion possible here.
{'description': 'Random forest model trained on simulated data for single '
                'grain cubic particles with 50 nm edge length with the '
                'external field applied parallel to the anisotropy axis.',
 'input_parameters': ['Ms (A/m)', 'A (J/m)', 'K1 (J/m^3)'],
 'model_name': 'cube50_singlegrain_random_forest_v0.1',
 'output_parameters': ['Hc (A/m)', 'Mr (A/m)', 'BHmax (J/m^3)'],
 'source': 'https://github.com/MaMMoS-project/ML-models/tree/main/beyond-stoner-wohlfarth/single-grain-easy-axis-model',
 'training_data_range': {'A': [1e-13 J / m, 1e-11 J / m],
                         'K': [10000.0 J / m3, 10000000.0 J / m3],
                         'Ms': [79580.0 A / m, 3980000.0 A / m]}}
```